### PR TITLE
fix the "Invalid header value" error

### DIFF
--- a/aerisweather/utils/AerisNetwork.py
+++ b/aerisweather/utils/AerisNetwork.py
@@ -18,7 +18,7 @@ class AerisNetwork:
             req = request.Request(url)
             try:
                 req.add_header('Referer', app_id)
-                req.add_header('User-Agent', "AerisPythonSDK/" + __version__ + "/Python/" + sys.version)
+                req.add_header('User-Agent', "AerisPythonSDK/" + __version__ + "/Python/" + sys.version.replace('\n', ''))
 
             except URLError:
                 # we don't need the extra headers, so let it pass if it fails here


### PR DESCRIPTION
I'm getting an error:
`ValueError: Invalid header value b'AerisPythonSDK/0.3.0/Python/3.6.8 (default, Jan  9 2019, 04:19:48) \n[GCC 6.3.0 20170516]'`

This should hopefully fix it.