### PR TITLE
Fix trailing comma with filters

### DIFF
--- a/aerisweather/aerisweather.py
+++ b/aerisweather/aerisweather.py
@@ -140,9 +140,7 @@ class AerisWeather:
 
         if filter_ is not None:
             if len(filter_) > 0:
-                url += "&filter="
-                for filt in filter_:
-                    url += filt.value + ","
+                url += "&filter=" + ",".join(filt.value for filt in filter_)
 
         out_query = self.query_str(query)
 


### PR DESCRIPTION
Haven't tested the old way more recently, but the API server stopped accepting a trailing comma on the `filter` field in mid-late January 2021.  Here's a quick patch to properly join filters.